### PR TITLE
chore: fix ci error

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"mocha": "^9.0.3",
 		"path": "^0.12.7",
 		"proxyquire": "^2.1.3",
-		"sinon": "^10.0.1",
+		"sinon": "^9.1.2",
 		"strip-ansi": "^6.0.0"
 	},
 	"funding": "https://opencollective.com/eslint"


### PR DESCRIPTION
This PR downgrades sinon to 9.1.2 to fix the CI error.